### PR TITLE
Add vagrantfiles for TeXLive

### DIFF
--- a/texlive2021/latex/Vagrantfile
+++ b/texlive2021/latex/Vagrantfile
@@ -1,0 +1,50 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"). You may
+# only use this file in accordance with the terms of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2021 David Stes
+#
+
+Vagrant.configure("2") do |config|
+
+    # Every Vagrant development environment requires a box. You can search for
+    # boxes at https://atlas.hashicorp.com/search.
+    config.vm.box = "openindiana/hipster"
+
+    # Disable automatic box update checking. If you disable this, then
+    # boxes will only be checked for updates when the user runs
+    # `vagrant box outdated`. This is not recommended.
+    config.vm.box_check_update = true
+
+    # Forward X11 to run GUI on the host
+    config.ssh.forward_agent = true
+    config.ssh.forward_x11 = true
+
+    config.vm.provision "shell", inline: <<-SHELL
+
+        echo "Test whether the latex profile exists"
+	test -f /vagrant/texlive.profile || exit -1
+
+        echo "Download install-tl"
+        pfexec wget -q -O install-tl-unx.tar.gz http://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz
+
+        echo "Extract install-tl"
+# could also --strip-components 1 -C install-tl-unx
+	pfexec gtar xfz install-tl-unx.tar.gz || exit -1
+
+# the install-tl script is in a directory that changes name every day
+	INSTALLTL=`find . -name install-tl -perm 755 -type f`
+	pfexec $INSTALLTL -profile /vagrant/texlive.profile
+    SHELL
+
+end
+

--- a/texlive2021/latex/texlive.profile
+++ b/texlive2021/latex/texlive.profile
@@ -1,0 +1,30 @@
+# texlive.profile written on Sun Sep 26 17:42:20 2021 UTC
+# It will NOT be updated and reflects only the
+# installation profile at installation time.
+selected_scheme scheme-basic
+TEXDIR /usr/texlive/2021
+TEXMFCONFIG ~/.texlive2021/texmf-config
+TEXMFHOME ~/texmf
+TEXMFLOCAL /usr/texlive/texmf-local
+TEXMFSYSCONFIG /usr/texlive/2021/texmf-config
+TEXMFSYSVAR /usr/texlive/2021/texmf-var
+TEXMFVAR ~/.texlive2021/texmf-var
+binary_i386-solaris 1
+instopt_adjustpath 1
+instopt_adjustrepo 1
+instopt_letter 0
+instopt_portable 0
+instopt_write18_restricted 1
+tlpdbopt_autobackup 1
+tlpdbopt_backupdir tlpkg/backups
+tlpdbopt_create_formats 1
+tlpdbopt_desktop_integration 1
+tlpdbopt_file_assocs 1
+tlpdbopt_generate_updmap 0
+tlpdbopt_install_docfiles 1
+tlpdbopt_install_srcfiles 1
+tlpdbopt_post_code 1
+tlpdbopt_sys_bin /usr/bin
+tlpdbopt_sys_info /usr/share/info
+tlpdbopt_sys_man /usr/share/man
+tlpdbopt_w32_multi_user 1

--- a/texlive2021/xetex/Vagrantfile
+++ b/texlive2021/xetex/Vagrantfile
@@ -1,0 +1,50 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"). You may
+# only use this file in accordance with the terms of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2021 David Stes
+#
+
+Vagrant.configure("2") do |config|
+
+    # Every Vagrant development environment requires a box. You can search for
+    # boxes at https://atlas.hashicorp.com/search.
+    config.vm.box = "openindiana/hipster"
+
+    # Disable automatic box update checking. If you disable this, then
+    # boxes will only be checked for updates when the user runs
+    # `vagrant box outdated`. This is not recommended.
+    config.vm.box_check_update = true
+
+    # Forward X11 to run GUI on the host
+    config.ssh.forward_agent = true
+    config.ssh.forward_x11 = true
+
+    config.vm.provision "shell", inline: <<-SHELL
+
+        echo "Test whether the latex profile exists"
+	test -f /vagrant/texlive.profile || exit -1
+
+        echo "Download install-tl"
+        pfexec wget -q -O install-tl-unx.tar.gz http://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz
+
+        echo "Extract install-tl"
+# could also --strip-components 1 -C install-tl-unx
+	pfexec gtar xfz install-tl-unx.tar.gz || exit -1
+
+# the install-tl script is in a directory that changes name every day
+	INSTALLTL=`find . -name install-tl -perm 755 -type f`
+	pfexec $INSTALLTL -profile /vagrant/texlive.profile
+    SHELL
+
+end
+

--- a/texlive2021/xetex/texlive.profile
+++ b/texlive2021/xetex/texlive.profile
@@ -1,0 +1,30 @@
+# texlive.profile written on Sun Sep 26 17:42:20 2021 UTC
+# It will NOT be updated and reflects only the
+# installation profile at installation time.
+selected_scheme scheme-small
+TEXDIR /usr/texlive/2021
+TEXMFCONFIG ~/.texlive2021/texmf-config
+TEXMFHOME ~/texmf
+TEXMFLOCAL /usr/texlive/texmf-local
+TEXMFSYSCONFIG /usr/texlive/2021/texmf-config
+TEXMFSYSVAR /usr/texlive/2021/texmf-var
+TEXMFVAR ~/.texlive2021/texmf-var
+binary_i386-solaris 1
+instopt_adjustpath 1
+instopt_adjustrepo 1
+instopt_letter 0
+instopt_portable 0
+instopt_write18_restricted 1
+tlpdbopt_autobackup 1
+tlpdbopt_backupdir tlpkg/backups
+tlpdbopt_create_formats 1
+tlpdbopt_desktop_integration 1
+tlpdbopt_file_assocs 1
+tlpdbopt_generate_updmap 0
+tlpdbopt_install_docfiles 1
+tlpdbopt_install_srcfiles 1
+tlpdbopt_post_code 1
+tlpdbopt_sys_bin /usr/bin
+tlpdbopt_sys_info /usr/share/info
+tlpdbopt_sys_man /usr/share/man
+tlpdbopt_w32_multi_user 1


### PR DESCRIPTION
The texlive.profile automatically selects either the latex or xetex profiles and installs the texlive 2021 distribution in a new VM.