### PR TITLE
Fix typo, change Pulseaudio tcp port from 4731 to 4713

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,10 @@ you can also play audiofiles in a Vagrant guest VM.
 
 See the PulseAudio X11 Credential Utility ('pax11publish') and 'paprefs' on the host for more information.
 
-By setting PULSE_SERVER="tcp:localhost:24713" and forwarding port 24713 on the
-guest to port 4713 on the host, the command 'pactl info' can be used,
+The command "paprefs" can be used to allow TCP connections to pulse.
+
+By setting PULSE_SERVER="tcp:localhost:24713" in the guest VM,
+and by forwarding port 24713 on the guest to port 4713 on the host,
+the command 'pactl info' can be used in the guest VM (or on the host),
 to check that you can connect to the pulse server on the host.
 

--- a/runtime/smalltalk/cog-spur/Vagrantfile
+++ b/runtime/smalltalk/cog-spur/Vagrantfile
@@ -30,7 +30,7 @@ Vagrant.configure("2") do |config|
     config.ssh.forward_x11 = true
 
     # Forward Pulseaudio to play Smalltalk audio on the host
-    config.ssh.extra_args = [ '-R', '24713:localhost:4731' ]
+    config.ssh.extra_args = [ '-R', '24713:localhost:4713' ]
 
     # Install the Cog-Spur VM and git clone the Cuis images
     config.vm.provision "shell", inline: <<-SHELL

--- a/runtime/smalltalk/cuis/Vagrantfile
+++ b/runtime/smalltalk/cuis/Vagrantfile
@@ -30,7 +30,7 @@ Vagrant.configure("2") do |config|
     config.ssh.forward_x11 = true
 
     # Forward Pulseaudio to play Smalltalk audio on the host
-    config.ssh.extra_args = [ '-R', '24713:localhost:4731' ]
+    config.ssh.extra_args = [ '-R', '24713:localhost:4713' ]
 
     # Install the Cog-Spur VM and git clone the Cuis images
     config.vm.provision "shell", inline: <<-SHELL

--- a/runtime/smalltalk/drgeo/Vagrantfile
+++ b/runtime/smalltalk/drgeo/Vagrantfile
@@ -30,7 +30,7 @@ Vagrant.configure("2") do |config|
     config.ssh.forward_x11 = true
 
     # Forward Pulseaudio to play Smalltalk audio on the host
-    config.ssh.extra_args = [ '-R', '24713:localhost:4731' ]
+    config.ssh.extra_args = [ '-R', '24713:localhost:4713' ]
 
     # Install the Cog-Spur VM and git clone the Cuis images
     config.vm.provision "shell", inline: <<-SHELL

--- a/runtime/smalltalk/squeak/Vagrantfile
+++ b/runtime/smalltalk/squeak/Vagrantfile
@@ -30,7 +30,7 @@ Vagrant.configure("2") do |config|
     config.ssh.forward_x11 = true
 
     # Forward Pulseaudio to play Smalltalk audio on the host
-    config.ssh.extra_args = [ '-R', '24713:localhost:4731' ]
+    config.ssh.extra_args = [ '-R', '24713:localhost:4713' ]
 
     config.vm.provision "shell", inline: <<-SHELL
 

--- a/runtime/smalltalk/stack-spur/Vagrantfile
+++ b/runtime/smalltalk/stack-spur/Vagrantfile
@@ -30,7 +30,7 @@ Vagrant.configure("2") do |config|
     config.ssh.forward_x11 = true
 
     # Forward Pulseaudio to play Smalltalk audio on the host
-    config.ssh.extra_args = [ '-R', '24713:localhost:4731' ]
+    config.ssh.extra_args = [ '-R', '24713:localhost:4713' ]
 
     # Install the Cog-Spur VM and git clone the Cuis images
     config.vm.provision "shell", inline: <<-SHELL


### PR DESCRIPTION

Used wrong tcp port in the last commit. typo  4731 instead of 4713.

The pax11publish command would usually report a port 4713 according to docs.