### PR TITLE
Mkdocs

### DIFF
--- a/oi-docs/Vagrantfile
+++ b/oi-docs/Vagrantfile
@@ -11,7 +11,7 @@
 #
 
 #
-# Copyright 2021 David Stes
+# Copyright 2021,2022 David Stes
 #
 
 Vagrant.configure("2") do |config|
@@ -42,7 +42,11 @@ Vagrant.configure("2") do |config|
 
 	# as of 21/9/2021 futures IPS is missing so install by pip
 	# as of 1/10/2022 pkg install mkdocs no longer works (pkg obsoleted)
-	pfexec pip install mkdocs==1.0.4
+	# pfexec pip install mkdocs==1.0.4 latest 1.4.0 also works for me
+	pfexec pip install mkdocs
+        # openindiana docs use the "spacelab' theme which is in :
+	pfexec pip install mkdocs-bootswatch
+	# without this you'd get Error: Unrecognised theme name: 'spacelab'
 
         echo "Run mkdocs by logging in (vagrant ssh)"
 	echo ""

--- a/oi-docs/Vagrantfile
+++ b/oi-docs/Vagrantfile
@@ -38,12 +38,11 @@ Vagrant.configure("2") do |config|
 	# library/python/futures seems to have a problem now
         pfexec pkg install -v \
 		git lynx links\
-		library/python/futures \
-		library/python/mkdocs \
 		developer/documentation-tool/mdl
 
 	# as of 21/9/2021 futures IPS is missing so install by pip
-	pfexec pip install futures
+	# as of 1/10/2022 pkg install mkdocs no longer works (pkg obsoleted)
+	pfexec pip install mkdocs==1.0.4
 
         echo "Run mkdocs by logging in (vagrant ssh)"
 	echo ""


### PR DESCRIPTION
change install method from pkg install mkdocs to pip install

this only applies to the Vagrantfile so the pkg install method can still be used on a regular Openindiana installation
